### PR TITLE
Refactor CompanyInfo model to remove address and businessDetails fields

### DIFF
--- a/models/master/CompanyInfo.js
+++ b/models/master/CompanyInfo.js
@@ -75,55 +75,6 @@ const companyInfoSchema = new mongoose.Schema(
         default: "",
       },
     },
-    address: {
-      streetAddress: {
-        type: String,
-        trim: true,
-        default: "",
-      },
-      city: {
-        type: String,
-        trim: true,
-        default: "",
-      },
-      stateProvince: {
-        type: String,
-        trim: true,
-        default: "",
-      },
-      zipPostalCode: {
-        type: String,
-        trim: true,
-        default: "",
-      },
-      country: {
-        type: String,
-        trim: true,
-        default: "",
-      },
-    },
-    businessDetails: {
-      industry: {
-        type: String,
-        trim: true,
-        default: "",
-      },
-      companySize: {
-        type: String,
-        trim: true,
-        default: "",
-      },
-      timezone: {
-        type: String,
-        trim: true,
-        default: "",
-      },
-      description: {
-        type: String,
-        trim: true,
-        default: "",
-      },
-    },
   },
   {
     timestamps: true,

--- a/services/master/companyInfoServices.js
+++ b/services/master/companyInfoServices.js
@@ -31,19 +31,6 @@ const sanitizeCompanyInfo = (companyInfo) => {
         contactEmail: "",
         phoneNumber: "",
       },
-      address: {
-        streetAddress: "",
-        city: "",
-        stateProvince: "",
-        zipPostalCode: "",
-        country: "",
-      },
-      businessDetails: {
-        industry: "",
-        companySize: "",
-        timezone: "",
-        description: "",
-      },
     };
   }
 
@@ -69,19 +56,6 @@ const sanitizeCompanyInfo = (companyInfo) => {
       contactEmail: infoObject.generalInformation?.contactEmail || "",
       phoneNumber: infoObject.generalInformation?.phoneNumber || "",
     },
-    address: {
-      streetAddress: infoObject.address?.streetAddress || "",
-      city: infoObject.address?.city || "",
-      stateProvince: infoObject.address?.stateProvince || "",
-      zipPostalCode: infoObject.address?.zipPostalCode || "",
-      country: infoObject.address?.country || "",
-    },
-    businessDetails: {
-      industry: infoObject.businessDetails?.industry || "",
-      companySize: infoObject.businessDetails?.companySize || "",
-      timezone: infoObject.businessDetails?.timezone || "",
-      description: infoObject.businessDetails?.description || "",
-    },
     createdAt: infoObject.createdAt,
     updatedAt: infoObject.updatedAt,
   };
@@ -102,39 +76,6 @@ const buildCompanyInfoUpdatePayload = (payload = {}) => {
     }
     if (Object.prototype.hasOwnProperty.call(payload.generalInformation, "phoneNumber")) {
       updateData["generalInformation.phoneNumber"] = normalizeString(payload.generalInformation.phoneNumber);
-    }
-  }
-
-  if (payload.address && typeof payload.address === "object") {
-    if (Object.prototype.hasOwnProperty.call(payload.address, "streetAddress")) {
-      updateData["address.streetAddress"] = normalizeString(payload.address.streetAddress);
-    }
-    if (Object.prototype.hasOwnProperty.call(payload.address, "city")) {
-      updateData["address.city"] = normalizeString(payload.address.city);
-    }
-    if (Object.prototype.hasOwnProperty.call(payload.address, "stateProvince")) {
-      updateData["address.stateProvince"] = normalizeString(payload.address.stateProvince);
-    }
-    if (Object.prototype.hasOwnProperty.call(payload.address, "zipPostalCode")) {
-      updateData["address.zipPostalCode"] = normalizeString(payload.address.zipPostalCode);
-    }
-    if (Object.prototype.hasOwnProperty.call(payload.address, "country")) {
-      updateData["address.country"] = normalizeString(payload.address.country);
-    }
-  }
-
-  if (payload.businessDetails && typeof payload.businessDetails === "object") {
-    if (Object.prototype.hasOwnProperty.call(payload.businessDetails, "industry")) {
-      updateData["businessDetails.industry"] = normalizeString(payload.businessDetails.industry);
-    }
-    if (Object.prototype.hasOwnProperty.call(payload.businessDetails, "companySize")) {
-      updateData["businessDetails.companySize"] = normalizeString(payload.businessDetails.companySize);
-    }
-    if (Object.prototype.hasOwnProperty.call(payload.businessDetails, "timezone")) {
-      updateData["businessDetails.timezone"] = normalizeString(payload.businessDetails.timezone);
-    }
-    if (Object.prototype.hasOwnProperty.call(payload.businessDetails, "description")) {
-      updateData["businessDetails.description"] = normalizeString(payload.businessDetails.description);
     }
   }
 

--- a/validations/master/companyInfoValidator.js
+++ b/validations/master/companyInfoValidator.js
@@ -1,6 +1,51 @@
 import { body, validationResult } from "express-validator";
 import { AppError } from "../../utils/errors.js";
 
+const normalizeWebsiteWithProtocol = (value) => {
+  const normalized = String(value || "").trim();
+
+  if (!normalized) {
+    return "";
+  }
+
+  if (/^https?:\/\//i.test(normalized)) {
+    return normalized;
+  }
+
+  return `https://${normalized}`;
+};
+
+const isValidHttpUrl = (value) => {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
+const isValidEmailAddress = (value) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+
+const normalizeOptionalWebsite = (value) => {
+  const normalized = normalizeWebsiteWithProtocol(value);
+
+  if (!normalized) {
+    return "";
+  }
+
+  return isValidHttpUrl(normalized) ? normalized : "";
+};
+
+const normalizeOptionalEmail = (value) => {
+  const normalized = String(value || "").trim().toLowerCase();
+
+  if (!normalized) {
+    return "";
+  }
+
+  return isValidEmailAddress(normalized) ? normalized : "";
+};
+
 const validationHandler = (req, _res, next) => {
   const errors = validationResult(req);
 
@@ -23,73 +68,22 @@ const updateCompanyInfoValidator = [
     .withMessage("generalInformation.companyName cannot exceed 200 characters"),
   body("generalInformation.website")
     .optional()
-    .trim()
-    .isURL({ require_protocol: true })
-    .withMessage("generalInformation.website must be a valid URL with protocol"),
+    .customSanitizer(normalizeOptionalWebsite),
   body("generalInformation.contactEmail")
     .optional()
-    .trim()
-    .isEmail()
-    .withMessage("generalInformation.contactEmail must be a valid email"),
+    .customSanitizer(normalizeOptionalEmail),
   body("generalInformation.phoneNumber")
     .optional()
     .trim()
     .isLength({ max: 100 })
     .withMessage("generalInformation.phoneNumber cannot exceed 100 characters"),
-  body("address.streetAddress")
-    .optional()
-    .trim()
-    .isLength({ max: 300 })
-    .withMessage("address.streetAddress cannot exceed 300 characters"),
-  body("address.city")
-    .optional()
-    .trim()
-    .isLength({ max: 150 })
-    .withMessage("address.city cannot exceed 150 characters"),
-  body("address.stateProvince")
-    .optional()
-    .trim()
-    .isLength({ max: 150 })
-    .withMessage("address.stateProvince cannot exceed 150 characters"),
-  body("address.zipPostalCode")
-    .optional()
-    .trim()
-    .isLength({ max: 30 })
-    .withMessage("address.zipPostalCode cannot exceed 30 characters"),
-  body("address.country")
-    .optional()
-    .trim()
-    .isLength({ max: 150 })
-    .withMessage("address.country cannot exceed 150 characters"),
-  body("businessDetails.industry")
-    .optional()
-    .trim()
-    .isLength({ max: 150 })
-    .withMessage("businessDetails.industry cannot exceed 150 characters"),
-  body("businessDetails.companySize")
-    .optional()
-    .trim()
-    .isLength({ max: 150 })
-    .withMessage("businessDetails.companySize cannot exceed 150 characters"),
-  body("businessDetails.timezone")
-    .optional()
-    .trim()
-    .isLength({ max: 150 })
-    .withMessage("businessDetails.timezone cannot exceed 150 characters"),
-  body("businessDetails.description")
-    .optional()
-    .trim()
-    .isLength({ max: 2000 })
-    .withMessage("businessDetails.description cannot exceed 2000 characters"),
   body().custom((value) => {
     const payload = value && typeof value === "object" ? value : {};
 
     const hasGeneralInformation = payload.generalInformation && Object.keys(payload.generalInformation).length > 0;
-    const hasAddress = payload.address && Object.keys(payload.address).length > 0;
-    const hasBusinessDetails = payload.businessDetails && Object.keys(payload.businessDetails).length > 0;
 
-    if (!hasGeneralInformation && !hasAddress && !hasBusinessDetails) {
-      throw new Error("At least one company info section is required.");
+    if (!hasGeneralInformation) {
+      throw new Error("generalInformation section is required.");
     }
 
     return true;


### PR DESCRIPTION
This pull request removes the `address` and `businessDetails` sections from the company info model and related service logic, simplifying the data structure to only include the `generalInformation` section. It also improves validation and normalization for website URLs and email addresses in the `generalInformation` section.

**Model and Data Structure Simplification:**

* Removed the `address` and `businessDetails` fields from the `CompanyInfo` Mongoose schema, so company info now only stores `generalInformation`.
* Updated service functions in `companyInfoServices.js` to stop handling or sanitizing `address` and `businessDetails` data, both when creating and updating company info. [[1]](diffhunk://#diff-bd29c5b012a2e419f8ef46cf5ba26082797b360497a0d6436e034f7491f3eebeL34-L46) [[2]](diffhunk://#diff-bd29c5b012a2e419f8ef46cf5ba26082797b360497a0d6436e034f7491f3eebeL72-L84) [[3]](diffhunk://#diff-bd29c5b012a2e419f8ef46cf5ba26082797b360497a0d6436e034f7491f3eebeL108-L140)

**Validation and Normalization Improvements:**

* Added custom sanitizers to normalize and validate website URLs (ensuring protocol) and email addresses in the `generalInformation` section, replacing the previous generic validators. [[1]](diffhunk://#diff-9803702a659b15c5793c5783be18553a8802b7f44845263a4a036323f1b724f8R4-R48) [[2]](diffhunk://#diff-9803702a659b15c5793c5783be18553a8802b7f44845263a4a036323f1b724f8L26-R86)
* Removed all validation rules for the now-deleted `address` and `businessDetails` fields. The validator now only requires the `generalInformation` section to be present in the payload.



<img width="1364" height="635" alt="image" src="https://github.com/user-attachments/assets/7f5539cb-e697-40af-b695-07267537f36c" />
<img width="1364" height="635" alt="image" src="https://github.com/user-attachments/assets/7f5539cb-e697-40af-b695-07267537f36c" />
