### PR TITLE
Enhance password reset functionality with company code and URL

### DIFF
--- a/controllers/tenant/agentControllers.js
+++ b/controllers/tenant/agentControllers.js
@@ -1,6 +1,6 @@
 import { logger } from "../../utils/logger.js";
 import { getMasterConnection } from "../../config/masterDB.js";
-import { TENANT_STATUS, USER_ROLES, USER_STATUS } from "../../constants/constants.js";
+import { APP_URL, TENANT_STATUS, USER_ROLES, USER_STATUS } from "../../constants/constants.js";
 import { BadRequestError, ForbiddenError, InternalServerError, NotFoundError, UnauthorizedError } from "../../utils/errors.js";
 import { resolveTenantDatabaseName } from "../../utils/tenantContext.js";
 
@@ -611,7 +611,9 @@ const requestPasswordReset = expressAsyncHandler(async (req, res) => {
 
     const response = await agentServices.requestPasswordReset({
       databaseName,
+      companyCode: normalizedCompanyCode,
       emailAddress,
+      resetUrl: `${APP_URL}/reset-password?companyCode=${encodeURIComponent(normalizedCompanyCode)}&emailAddress=${encodeURIComponent(String(emailAddress || "").trim().toLowerCase())}`,
     });
 
     res.status(200).json({

--- a/services/tenant/agentServices.js
+++ b/services/tenant/agentServices.js
@@ -534,7 +534,7 @@ const verifyAgentPassword = async (payload) => {
 
 const requestPasswordReset = async (payload) => {
   try {
-    const { databaseName, emailAddress } = payload || {};
+    const { databaseName, companyCode, emailAddress, resetUrl } = payload || {};
 
     if (!databaseName) {
       throw new BadRequestError("databaseName is required");
@@ -580,9 +580,11 @@ const requestPasswordReset = async (payload) => {
       subject: "Password Reset - One-Time Password",
       html: baseEmailTemplate(
         passwordResetOTPEmail({
+          companyCode,
           email: normalizedEmail,
           otp,
           expiresInMinutes: OTP_EXPIRY_MINUTES,
+          resetUrl,
         }),
       ),
     });

--- a/templates/base-email/agents/passwordResetOTPEmail.js
+++ b/templates/base-email/agents/passwordResetOTPEmail.js
@@ -6,9 +6,17 @@ const escapeHtml = (value = "") =>
     .replace(/\"/g, "&quot;")
     .replace(/'/g, "&#39;");
 
-const passwordResetOTPEmail = ({ email = "", otp = "", expiresInMinutes = 10 }) => {
+const passwordResetOTPEmail = ({
+    companyCode = "",
+    email = "",
+    otp = "",
+    expiresInMinutes = 10,
+    resetUrl = "",
+}) => {
+    const escapedCompanyCode = escapeHtml(companyCode);
   const escapedEmail = escapeHtml(email);
   const escapedOTP = escapeHtml(otp);
+    const escapedResetUrl = escapeHtml(resetUrl);
 
   return `
     <h2 style="font-family: Arial, sans-serif; font-size: 28px; font-weight: bold; color: rgb(15, 23, 42); margin: 0 0 8px 0; line-height: 1.3;">
@@ -17,6 +25,12 @@ const passwordResetOTPEmail = ({ email = "", otp = "", expiresInMinutes = 10 }) 
     <p style="font-family: Arial, sans-serif; font-size: 15px; color: rgb(71, 85, 105); margin: 0 0 12px 0; line-height: 1.75;">
         We received a request to reset the password for your JAF Chatra account associated with <strong style="color: rgb(15, 23, 42);">${escapedEmail}</strong>.
     </p>
+        ${escapedCompanyCode
+            ? `<p style="font-family: Arial, sans-serif; font-size: 13px; color: rgb(71, 85, 105); margin: 0 0 12px 0; line-height: 1.75;">
+                Company Code: <strong style="color: rgb(15, 23, 42);">${escapedCompanyCode}</strong>
+            </p>`
+            : ""
+        }
     <p style="font-family: Arial, sans-serif; font-size: 14px; color: rgb(100, 116, 139); margin: 0 0 28px 0; line-height: 1.7;">
         Use the One-Time Password (OTP) below to verify your identity and reset your password. This code will expire in ${expiresInMinutes} minutes.
     </p>
@@ -37,6 +51,18 @@ const passwordResetOTPEmail = ({ email = "", otp = "", expiresInMinutes = 10 }) 
             If you did not request a password reset, please ignore this email or contact our support team. Do not share this OTP with anyone.
         </p>
     </div>
+
+        ${escapedResetUrl
+            ? `<div style="margin-bottom: 28px; text-align: center;">
+                <a href="${escapedResetUrl}" style="display: inline-block; border-radius: 8px; background-color: rgb(8, 145, 178); color: rgb(255, 255, 255); text-decoration: none; font-family: Arial, sans-serif; font-size: 14px; font-weight: 700; padding: 12px 20px;">
+                    Reset Password
+                </a>
+                <p style="font-family: Arial, sans-serif; font-size: 11px; color: rgb(100, 116, 139); margin: 10px 0 0 0; line-height: 1.6;">
+                    This button opens the reset password page. You still need the OTP above to finish the password reset.
+                </p>
+            </div>`
+            : ""
+        }
 
     <div style="height: 1px; background-color: rgb(226, 232, 240); margin-bottom: 28px;"></div>
 


### PR DESCRIPTION
This pull request enhances the password reset flow for agents by including the company code and a direct reset link in the password reset email. These improvements make the reset process clearer and more user-friendly, especially for multi-tenant scenarios.

**Password Reset Flow Enhancements:**

* The password reset email now includes the `companyCode` and a `resetUrl` link, making it easier for users to identify their company and directly access the password reset page. [[1]](diffhunk://#diff-c8b93c1ec1ed777a72e6c7972bbaa435b54738352afac3d8ca827f2e561e50d7R614-R616) [[2]](diffhunk://#diff-5f822cd103ad226678eedbf2b657c4c5464c9381ccfe471aad8bbcebd40e6b18L537-R537) [[3]](diffhunk://#diff-5f822cd103ad226678eedbf2b657c4c5464c9381ccfe471aad8bbcebd40e6b18R583-R587)
* The email template (`passwordResetOTPEmail`) has been updated to:
  * Display the company code if provided.
  * Add a "Reset Password" button that links to the provided `resetUrl`, along with a note that the OTP is still required to complete the reset.
  * Properly escape all user-provided values to prevent HTML injection.

**Configuration and Dependency Updates:**

* The `APP_URL` constant is now imported in the agent controller to construct the password reset link.