### PR TITLE
Improve password reset request error handling and messaging

### DIFF
--- a/controllers/tenant/agentControllers.js
+++ b/controllers/tenant/agentControllers.js
@@ -612,11 +612,7 @@ const requestPasswordReset = expressAsyncHandler(async (req, res) => {
     }).lean();
 
     if (!tenant) {
-      // Don't reveal if company code exists (security best practice)
-      return res.status(200).json({
-        success: true,
-        message: "If the account exists, a password reset OTP has been sent.",
-      });
+      throw new BadRequestError("Invalid company code or email. Please check and try again.");
     }
 
     const databaseName = tenant.databaseName;

--- a/services/tenant/agentServices.js
+++ b/services/tenant/agentServices.js
@@ -652,8 +652,7 @@ const requestPasswordReset = async (payload) => {
     }).lean();
 
     if (!agent) {
-      // Don't reveal if email exists or not (security best practice)
-      return { message: "If the email exists, a password reset OTP has been sent." };
+      throw new BadRequestError("Invalid company code or email. Please check and try again.");
     }
 
     // Generate OTP
@@ -690,7 +689,7 @@ const requestPasswordReset = async (payload) => {
 
     logger.info(`Password reset OTP sent to ${normalizedEmail}`);
 
-    return { message: "If the email exists, a password reset OTP has been sent." };
+    return { message: "A password reset OTP has been sent." };
   } catch (error) {
     logger.error(`Error requesting password reset: ${error.message}`);
 


### PR DESCRIPTION
This pull request updates the password reset logic to provide more explicit error messages about invalid credentials and to clarify the success message when an OTP is sent. The main changes are focused on improving user feedback and error handling in both the controller and service layers.

**Error handling and user feedback improvements:**

* [`controllers/tenant/agentControllers.js`](diffhunk://#diff-c8b93c1ec1ed777a72e6c7972bbaa435b54738352afac3d8ca827f2e561e50d7L615-R615): Now throws a `BadRequestError` with a clear message ("Invalid company code or email. Please check and try again.") if the tenant is not found, instead of always returning a generic success message.
* [`services/tenant/agentServices.js`](diffhunk://#diff-5f822cd103ad226678eedbf2b657c4c5464c9381ccfe471aad8bbcebd40e6b18L655-R655): Throws a `BadRequestError` with the same explicit message if the agent is not found, replacing the previous generic response.
* [`services/tenant/agentServices.js`](diffhunk://#diff-5f822cd103ad226678eedbf2b657c4c5464c9381ccfe471aad8bbcebd40e6b18L693-R692): Updates the success message returned after sending an OTP to be more direct ("A password reset OTP has been sent.") rather than ambiguous.